### PR TITLE
check_challenge_shellscript() breaks if script was launched with a relative path

### DIFF
--- a/chio.py
+++ b/chio.py
@@ -138,10 +138,15 @@ def check_challenge_shellscript(process):
 
     assert os.path.basename(process.exe()) in [ 'sh', 'bash' ], f"Process interpreter must be 'sh' or 'bash'. Yours is: {os.path.basename(process.exe())}"
     assert len(process.cmdline()) > 1, "The shell must be running in non-interactive mode (with a script)!"
-    if process.cmdline()[1] == "-c":
-        assert process.cmdline()[3].startswith("/challenge"), f"The shell process must be executing a shell script under /challenge! Yours is: {process.cmdline()[3]}"
-    else:
-        assert process.cmdline()[1].startswith("/challenge"), f"The shell process must be executing a shell script under /challenge! Yours is: {process.cmdline()[1]}"
+
+    script_path = process.cmdline()[1]
+    if script_path == "-c":
+        script_path = process.cmdline()[3]
+
+    if not script_path.startswith("/"):
+        script_path = os.path.abspath(script_path)
+
+    assert script_path.startswith("/challenge/"), f"The shell process must be executing a shell script under /challenge! Yours is: {script_path}"
 
 PROCESS_TYPE_CHECKERS = {
     'python': check_python,


### PR DESCRIPTION
One of my students uncovered a minor (but frustrating) bug/limitation in `chio` that's causing it to reject what I'm pretty sure should be a valid solution to the `linux-luminarium/piping/tee` level.

Basically, when the level's `pwn` and `college` scripts check to make sure their pipe ends are connected correctly to each other, they're expecting to have been executed like:

`/challenge/pwn --secret <...> | /challenge/college`

...but they don't recognize the connection if you first `cd` to `/challenge` and run them as:

`./pwn --secret <...> | ./college`

It does, however, work fine if `tee` is put in the middle (since then the programs are looking at `tee` instead of each other, bypassing the issue).

To make this more robust, when the script's path doesn't begin with `/`, we can instead ask the OS to resolve its basepath relative to our (and hopefully also the shell's) CWD. That should work no matter where the script was launched from, assuming the script makes all its calls to `chio` before making any changes to its own CWD.

I've tested that this works well on `linux-luminarium/piping/tee`, but it may require regression testing on other levels if they also rely on this code.